### PR TITLE
Update QLearningDiscrete.java

### DIFF
--- a/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/sync/qlearning/discrete/QLearningDiscrete.java
+++ b/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/sync/qlearning/discrete/QLearningDiscrete.java
@@ -190,11 +190,19 @@ public abstract class QLearningDiscrete<O extends Encodable> extends QLearning<O
             }
 
             double previousV = dqnOutputAr.getDouble(i, actions[i]);
-            double lowB = previousV - getConfiguration().getErrorClamp();
-            double highB = previousV + getConfiguration().getErrorClamp();
-            double clamped = Math.min(highB, Math.max(yTar, lowB));
+            double tdError = yTar - previousV;
+            double clamp =  getConfiguration().getErrorClamp();
+            
+            if (Math.abs(tdError) > clamp) {
+                if (tdError < clamp) {
+                    tdError = clamp;
+                }
+                if (tdError > clamp) {
+                    tdError = -clamp;
+                }
+            }
 
-            dqnOutputAr.putScalar(i, actions[i], clamped);
+            dqnOutputAr.putScalar(i, actions[i], tdError);
         }
 
         return new Pair(obs, dqnOutputAr);


### PR DESCRIPTION
Not sure if td error was computed correctly here, see example computation below? Example of clamping here:
https://github.com/karpathy/reinforcejs/blob/master/lib/rl.js#L1108

Example of previous code:
r + y * V = 10
prev V = 8
clamp = 1
=>
lowB = 7
highB = 9

Result:
clamped = min(9, max (10, 7) ) = 9
actual tdError = 10 - 8 = 2

Thoughts?