### PR TITLE
Work around issue with updating gradient from another model

### DIFF
--- a/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/async/AsyncThread.java
+++ b/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/async/AsyncThread.java
@@ -68,7 +68,7 @@ public abstract class AsyncThread<O extends Encodable, A, AS extends ActionSpace
                 double score = subEpochReturn.getScore();
                 if (getMdp().isDone()) {
 
-                    if (getThreadNumber() == 1)
+                    if (getThreadNumber() == 0)
                         getDataManager().appendStat(
                                         new AsyncStatEntry(getStepCounter(), epochCounter, rewards, length, score));
 

--- a/rl4j-core/src/main/java/org/deeplearning4j/rl4j/network/ac/ActorCriticCompGraph.java
+++ b/rl4j-core/src/main/java/org/deeplearning4j/rl4j/network/ac/ActorCriticCompGraph.java
@@ -1,5 +1,6 @@
 package org.deeplearning4j.rl4j.network.ac;
 
+import org.deeplearning4j.nn.gradient.DefaultGradient;
 import org.deeplearning4j.nn.gradient.Gradient;
 import org.deeplearning4j.nn.graph.ComputationGraph;
 import org.deeplearning4j.util.ModelSerializer;
@@ -44,8 +45,10 @@ public class ActorCriticCompGraph implements IActorCritic {
 
 
     public void applyGradient(Gradient[] gradient, int batchSize) {
-        cg.getUpdater().update(gradient[0], 1, batchSize);
-        cg.params().subi(gradient[0].gradient());
+        INDArray g = cg.getFlattenedGradients();
+        g.assign(gradient[0].gradient());
+        cg.getUpdater().update(new DefaultGradient(g), 1, batchSize);
+        cg.params().subi(g);
     }
 
     public double getLatestScore() {

--- a/rl4j-core/src/main/java/org/deeplearning4j/rl4j/network/ac/ActorCriticSeparate.java
+++ b/rl4j-core/src/main/java/org/deeplearning4j/rl4j/network/ac/ActorCriticSeparate.java
@@ -1,6 +1,7 @@
 package org.deeplearning4j.rl4j.network.ac;
 
 import org.apache.commons.lang3.NotImplementedException;
+import org.deeplearning4j.nn.gradient.DefaultGradient;
 import org.deeplearning4j.nn.gradient.Gradient;
 import org.deeplearning4j.nn.graph.ComputationGraph;
 import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
@@ -52,10 +53,15 @@ public class ActorCriticSeparate implements IActorCritic {
 
 
     public void applyGradient(Gradient[] gradient, int batchSize) {
-        valueNet.getUpdater().update(valueNet, gradient[0], 1, batchSize);
-        valueNet.params().subi(gradient[0].gradient());
-        policyNet.getUpdater().update(policyNet, gradient[1], 1, batchSize);
-        policyNet.params().subi(gradient[1].gradient());
+        INDArray g0 = valueNet.getFlattenedGradients();
+        g0.assign(gradient[0].gradient());
+        valueNet.getUpdater().update(valueNet, new DefaultGradient(g0), 1, batchSize);
+        valueNet.params().subi(g0);
+
+        INDArray g1 = policyNet.getFlattenedGradients();
+        g1.assign(gradient[1].gradient());
+        policyNet.getUpdater().update(policyNet, new DefaultGradient(g1), 1, batchSize);
+        policyNet.params().subi(g1);
     }
 
     public double getLatestScore() {

--- a/rl4j-core/src/main/java/org/deeplearning4j/rl4j/network/dqn/DQN.java
+++ b/rl4j-core/src/main/java/org/deeplearning4j/rl4j/network/dqn/DQN.java
@@ -1,5 +1,6 @@
 package org.deeplearning4j.rl4j.network.dqn;
 
+import org.deeplearning4j.nn.gradient.DefaultGradient;
 import org.deeplearning4j.nn.gradient.Gradient;
 import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
 import org.deeplearning4j.util.ModelSerializer;
@@ -64,8 +65,10 @@ public class DQN implements IDQN {
     }
 
     public void applyGradient(Gradient[] gradient, int batchSize) {
-        mln.getUpdater().update(mln, gradient[0], 1, batchSize);
-        mln.params().subi(gradient[0].gradient());
+        INDArray g = mln.getFlattenedGradients();
+        g.assign(gradient[0].gradient());
+        mln.getUpdater().update(mln, new DefaultGradient(g), 1, batchSize);
+        mln.params().subi(g);
     }
 
     public double getLatestScore() {


### PR DESCRIPTION
Fixes #37 

## What changes were proposed in this pull request?

Deeplearning4j currently has problems when updating a gradient that was computed in another model (https://github.com/deeplearning4j/deeplearning4j/pull/3545). Copying the gradient to the model we intend to apply it to anyway works around this issue.

## How was this patch tested?

The AsyncNStepCartpole and A3CCartpole examples kind of work like they kind of work under 0.8.0.
