### PR TITLE
Migrate core classes to rl4j-api, anticipate gym deprecation

### DIFF
--- a/rl4j-api/src/main/java/org/deeplearning4j/rl4j/mdp/MDP.java
+++ b/rl4j-api/src/main/java/org/deeplearning4j/rl4j/mdp/MDP.java
@@ -1,7 +1,6 @@
 package org.deeplearning4j.rl4j.mdp;
 
 
-import org.deeplearning4j.gym.StepReply;
 import org.deeplearning4j.rl4j.space.ActionSpace;
 import org.deeplearning4j.rl4j.space.ObservationSpace;
 

--- a/rl4j-api/src/main/java/org/deeplearning4j/rl4j/mdp/StepReply.java
+++ b/rl4j-api/src/main/java/org/deeplearning4j/rl4j/mdp/StepReply.java
@@ -1,0 +1,20 @@
+package org.deeplearning4j.rl4j.mdp;
+
+import lombok.Value;
+import org.json.JSONObject;
+
+/**
+ * @param <T> type of observation
+ * @author rubenfiszel (ruben.fiszel@epfl.ch) on 7/6/16.
+ *
+ *  StepReply is the container for the data returned after each step(action).
+ */
+@Value
+public class StepReply<T> {
+
+    T observation;
+    double reward;
+    boolean done;
+    JSONObject info;
+
+}

--- a/rl4j-api/src/main/java/org/deeplearning4j/rl4j/space/ActionSpace.java
+++ b/rl4j-api/src/main/java/org/deeplearning4j/rl4j/space/ActionSpace.java
@@ -1,0 +1,26 @@
+package org.deeplearning4j.rl4j.space;
+
+/**
+ * @param <A> the type of Action
+ * @author rubenfiszel (ruben.fiszel@epfl.ch) on 7/8/16.
+ *         <p>
+ *         Should contain contextual information about the Action space, which is the space of all the actions that could be available.
+ *         Also must know how to return a randomly uniformly sampled action.
+ */
+public interface ActionSpace<A> {
+
+    /**
+     * @return A randomly uniformly sampled action,
+     */
+    A randomAction();
+
+    void setSeed(int seed);
+
+    Object encode(A action);
+
+    int getSize();
+
+    A noOp();
+
+
+}

--- a/rl4j-api/src/main/java/org/deeplearning4j/rl4j/space/ArrayObservationSpace.java
+++ b/rl4j-api/src/main/java/org/deeplearning4j/rl4j/space/ArrayObservationSpace.java
@@ -1,0 +1,29 @@
+package org.deeplearning4j.rl4j.space;
+
+import lombok.Value;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.factory.Nd4j;
+
+/**
+ * @param <O> the type of Observation
+ * @author rubenfiszel (ruben.fiszel@epfl.ch) on 7/8/16.
+ *         <p>
+ *         An array observation space enables you to create an Observation Space of custom dimension
+ */
+
+@Value
+public class ArrayObservationSpace<O> implements ObservationSpace<O> {
+
+    String name;
+    int[] shape;
+    INDArray low;
+    INDArray high;
+
+    public ArrayObservationSpace(int[] shape) {
+        name = "Custom";
+        this.shape = shape;
+        low = Nd4j.create(1);
+        high = Nd4j.create(1);
+    }
+
+}

--- a/rl4j-api/src/main/java/org/deeplearning4j/rl4j/space/Box.java
+++ b/rl4j-api/src/main/java/org/deeplearning4j/rl4j/space/Box.java
@@ -1,0 +1,29 @@
+package org.deeplearning4j.rl4j.space;
+
+import org.json.JSONArray;
+
+/**
+ * @author rubenfiszel (ruben.fiszel@epfl.ch) on 7/8/16.
+ *
+ * A Box observation
+ *
+ * @see <a href="https://gym.openai.com/envs#box2d">https://gym.openai.com/envs#box2d</a>
+ */
+public class Box implements Encodable {
+
+    private final double[] array;
+
+    public Box(JSONArray arr) {
+
+        int lg = arr.length();
+        this.array = new double[lg];
+
+        for (int i = 0; i < lg; i++) {
+            this.array[i] = arr.getDouble(i);
+        }
+    }
+
+    public double[] toArray() {
+        return array;
+    }
+}

--- a/rl4j-api/src/main/java/org/deeplearning4j/rl4j/space/DiscreteSpace.java
+++ b/rl4j-api/src/main/java/org/deeplearning4j/rl4j/space/DiscreteSpace.java
@@ -1,0 +1,43 @@
+package org.deeplearning4j.rl4j.space;
+
+import lombok.Getter;
+
+import java.util.Random;
+
+/**
+ * @author rubenfiszel (ruben.fiszel@epfl.ch) on 7/8/16.
+ *         <p>
+ *         A discrete space of action. A discrete space is always isomorphic
+ *         to a space of integer so we can parametrize directly by Integer.
+ *         Benefit of using Integers directly is that you can use it as the
+ *         id of the node assigned to that action in the outpout of a DQN.
+ */
+public class DiscreteSpace implements ActionSpace<Integer> {
+
+    //size of the space also defined as the number of different actions
+    @Getter
+    final protected int size;
+    protected Random rd;
+
+    public DiscreteSpace(int size) {
+        this.size = size;
+        rd = new Random();
+    }
+
+    public Integer randomAction() {
+        return rd.nextInt(size);
+    }
+
+    public void setSeed(int seed) {
+        rd = new Random(seed);
+    }
+
+    public Object encode(Integer a) {
+        return a;
+    }
+
+    public Integer noOp() {
+        return 0;
+    }
+
+}

--- a/rl4j-api/src/main/java/org/deeplearning4j/rl4j/space/Encodable.java
+++ b/rl4j-api/src/main/java/org/deeplearning4j/rl4j/space/Encodable.java
@@ -1,0 +1,16 @@
+package org.deeplearning4j.rl4j.space;
+
+/**
+ * @author rubenfiszel (ruben.fiszel@epfl.ch) on 7/19/16.
+ *         Encodable is an interface that ensure that the state is convertible to a double array
+ */
+public interface Encodable {
+
+    /**
+     * $
+     * encodes all the information of an Observation in an array double and can be used as input of a DQN directly
+     *
+     * @return the encoded informations
+     */
+    double[] toArray();
+}

--- a/rl4j-api/src/main/java/org/deeplearning4j/rl4j/space/HighLowDiscrete.java
+++ b/rl4j-api/src/main/java/org/deeplearning4j/rl4j/space/HighLowDiscrete.java
@@ -1,0 +1,32 @@
+package org.deeplearning4j.rl4j.space;
+
+import lombok.Value;
+import org.json.JSONArray;
+import org.nd4j.linalg.api.ndarray.INDArray;
+
+
+/**
+ * @author rubenfiszel (ruben.fiszel@epfl.ch) on 7/26/16.
+ */
+@Value
+public class HighLowDiscrete extends DiscreteSpace {
+
+    //size of the space also defined as the number of different actions
+    INDArray matrix;
+
+    public HighLowDiscrete(INDArray matrix) {
+        super(matrix.rows());
+        this.matrix = matrix;
+    }
+
+    @Override
+    public Object encode(Integer a) {
+        JSONArray jsonArray = new JSONArray();
+        for (int i = 0; i < size; i++) {
+            jsonArray.put(matrix.getDouble(i, 0));
+        }
+        jsonArray.put(a - 1, matrix.getDouble(a - 1, 1));
+        return jsonArray;
+    }
+
+}

--- a/rl4j-api/src/main/java/org/deeplearning4j/rl4j/space/ObservationSpace.java
+++ b/rl4j-api/src/main/java/org/deeplearning4j/rl4j/space/ObservationSpace.java
@@ -1,0 +1,19 @@
+package org.deeplearning4j.rl4j.space;
+
+import org.nd4j.linalg.api.ndarray.INDArray;
+
+/**
+ * @author rubenfiszel (ruben.fiszel@epfl.ch) on 8/11/16.
+ *         An observation space contains the basic informations about the state space
+ */
+public interface ObservationSpace<O> {
+
+    String getName();
+
+    int[] getShape();
+
+    INDArray getLow();
+
+    INDArray getHigh();
+
+}

--- a/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/Learning.java
+++ b/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/Learning.java
@@ -4,7 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
-import org.deeplearning4j.gym.StepReply;
+import org.deeplearning4j.rl4j.mdp.StepReply;
 import org.deeplearning4j.rl4j.mdp.MDP;
 import org.deeplearning4j.rl4j.network.NeuralNet;
 import org.deeplearning4j.rl4j.space.ActionSpace;

--- a/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/async/AsyncThreadDiscrete.java
+++ b/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/async/AsyncThreadDiscrete.java
@@ -1,7 +1,7 @@
 package org.deeplearning4j.rl4j.learning.async;
 
 import lombok.Getter;
-import org.deeplearning4j.gym.StepReply;
+import org.deeplearning4j.rl4j.mdp.StepReply;
 import org.deeplearning4j.nn.gradient.Gradient;
 import org.deeplearning4j.rl4j.learning.IHistoryProcessor;
 import org.deeplearning4j.rl4j.learning.Learning;

--- a/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/sync/qlearning/QLearning.java
+++ b/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/sync/qlearning/QLearning.java
@@ -2,7 +2,7 @@ package org.deeplearning4j.rl4j.learning.sync.qlearning;
 
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
-import org.deeplearning4j.gym.StepReply;
+import org.deeplearning4j.rl4j.mdp.StepReply;
 import org.deeplearning4j.rl4j.learning.sync.ExpReplay;
 import org.deeplearning4j.rl4j.learning.sync.IExpReplay;
 import org.deeplearning4j.rl4j.learning.sync.SyncLearning;

--- a/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/sync/qlearning/discrete/QLearningDiscrete.java
+++ b/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/sync/qlearning/discrete/QLearningDiscrete.java
@@ -3,7 +3,7 @@ package org.deeplearning4j.rl4j.learning.sync.qlearning.discrete;
 import lombok.Getter;
 import lombok.Setter;
 import org.nd4j.linalg.primitives.Pair;
-import org.deeplearning4j.gym.StepReply;
+import org.deeplearning4j.rl4j.mdp.StepReply;
 import org.deeplearning4j.rl4j.learning.Learning;
 import org.deeplearning4j.rl4j.learning.sync.Transition;
 import org.deeplearning4j.rl4j.learning.sync.qlearning.QLearning;

--- a/rl4j-core/src/main/java/org/deeplearning4j/rl4j/mdp/toy/HardDeteministicToy.java
+++ b/rl4j-core/src/main/java/org/deeplearning4j/rl4j/mdp/toy/HardDeteministicToy.java
@@ -1,7 +1,7 @@
 package org.deeplearning4j.rl4j.mdp.toy;
 
 import lombok.Getter;
-import org.deeplearning4j.gym.StepReply;
+import org.deeplearning4j.rl4j.mdp.StepReply;
 import org.deeplearning4j.rl4j.mdp.MDP;
 import org.deeplearning4j.rl4j.network.dqn.IDQN;
 import org.deeplearning4j.rl4j.space.ArrayObservationSpace;

--- a/rl4j-core/src/main/java/org/deeplearning4j/rl4j/mdp/toy/SimpleToy.java
+++ b/rl4j-core/src/main/java/org/deeplearning4j/rl4j/mdp/toy/SimpleToy.java
@@ -3,7 +3,7 @@ package org.deeplearning4j.rl4j.mdp.toy;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
-import org.deeplearning4j.gym.StepReply;
+import org.deeplearning4j.rl4j.mdp.StepReply;
 import org.deeplearning4j.rl4j.learning.NeuralNetFetchable;
 import org.deeplearning4j.rl4j.mdp.MDP;
 import org.deeplearning4j.rl4j.network.dqn.IDQN;

--- a/rl4j-core/src/main/java/org/deeplearning4j/rl4j/policy/Policy.java
+++ b/rl4j-core/src/main/java/org/deeplearning4j/rl4j/policy/Policy.java
@@ -1,6 +1,6 @@
 package org.deeplearning4j.rl4j.policy;
 
-import org.deeplearning4j.gym.StepReply;
+import org.deeplearning4j.rl4j.mdp.StepReply;
 import org.deeplearning4j.rl4j.learning.IHistoryProcessor;
 import org.deeplearning4j.rl4j.learning.Learning;
 import org.deeplearning4j.rl4j.learning.sync.Transition;

--- a/rl4j-doom/src/main/java/org/deeplearning4j/rl4j/mdp/vizdoom/VizDoom.java
+++ b/rl4j-doom/src/main/java/org/deeplearning4j/rl4j/mdp/vizdoom/VizDoom.java
@@ -6,7 +6,7 @@ import lombok.Setter;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 import org.bytedeco.javacpp.Pointer;
-import org.deeplearning4j.gym.StepReply;
+import org.deeplearning4j.rl4j.mdp.StepReply;
 import org.deeplearning4j.rl4j.mdp.MDP;
 import org.deeplearning4j.rl4j.space.ArrayObservationSpace;
 import org.deeplearning4j.rl4j.space.DiscreteSpace;


### PR DESCRIPTION
## What changes were proposed in this pull request?

rl4j-api MDP interface depends on core classes from the java gym client. This is awkward since the MDP model is expansive beyond the gym and can be used in a variety of cases. This PR migrates these classes to the rl4j-api in anticipation of gym deprecation.

## How was this patch tested?

Manual tests and local integration.