### PR TITLE
Update URL of local nexus repo, as we moved from Nexus v2 to v3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -297,16 +297,16 @@
                     <id>local-nexus</id>
                     <name>local-nexus</name>
                     <url>
-                        http://master-jenkins.skymind.io:8088/nexus/content/repositories/snapshots
+                        http://master-jenkins.skymind.io:8088/repository/snapshots
                     </url>
                 </snapshotRepository>
-                <repository>
-                    <id>local-nexus</id>
-                    <name>local-nexus</name>
-                    <url>
-                        http://master-jenkins.skymind.io:8088/nexus/service/local/staging/deploy/maven2
-                    </url>
-                </repository>
+                <!-- <repository> -->
+                <!--     <id>local-nexus</id> -->
+                <!--     <name>local-nexus</name> -->
+                <!--     <url> -->
+                <!--         http://master-jenkins.skymind.io:8088/service/local/staging/deploy/maven2 -->
+                <!--     </url> -->
+                <!-- </repository> -->
             </distributionManagement>
             <build>
                 <plugins>
@@ -333,7 +333,7 @@
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>local-nexus</serverId>
-                            <nexusUrl>http://master-jenkins.skymind.io:8088/nexus/</nexusUrl>
+                            <nexusUrl>http://master-jenkins.skymind.io:8088/</nexusUrl>
                             <skipStagingRepositoryClose>true</skipStagingRepositoryClose>
                         </configuration>
                     </plugin>


### PR DESCRIPTION
(Please fill in changes proposed in this fix)


(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

Please review
https://github.com/deeplearning4j/deeplearning4j/blob/master/CONTRIBUTING.md before opening a pull request.

make clear the staging repo is inoperant, as Nexus Pro is not deployed