### PR TITLE
Stop type leakage in EpsGreedy

### DIFF
--- a/rl4j-api/src/main/java/org/deeplearning4j/rl4j/mdp/HasActionSpace.java
+++ b/rl4j-api/src/main/java/org/deeplearning4j/rl4j/mdp/HasActionSpace.java
@@ -1,0 +1,8 @@
+package org.deeplearning4j.rl4j.mdp;
+
+import org.deeplearning4j.rl4j.space.ActionSpace;
+import org.deeplearning4j.rl4j.space.ObservationSpace;
+
+public interface HasActionSpace<A> {
+    ActionSpace<A> getActionSpace();
+}

--- a/rl4j-api/src/main/java/org/deeplearning4j/rl4j/mdp/MDP.java
+++ b/rl4j-api/src/main/java/org/deeplearning4j/rl4j/mdp/MDP.java
@@ -10,16 +10,13 @@ import org.deeplearning4j.rl4j.space.ObservationSpace;
  * An interface that ensure an environment is expressible as a
  * Markov Decsision Process. This implementation follow the gym model.
  * It works based on side effects which is perfect for imperative simulation.
- *
+ * <p>
  * A bit sad that it doesn't use efficiently stateful mdp that could be rolled back
  * in a "functionnal manner" if step return a mdp
- *
  */
-public interface MDP<O, A, AS extends ActionSpace<A>> {
+public interface MDP<O, A, AS extends ActionSpace<A>> extends HasActionSpace<A> {
 
     ObservationSpace<O> getObservationSpace();
-
-    AS getActionSpace();
 
     O reset();
 

--- a/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/Learning.java
+++ b/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/Learning.java
@@ -30,8 +30,8 @@ public abstract class Learning<O extends Encodable, A, AS extends ActionSpace<A>
     @Getter
     final private Random random;
 
-    @Getter
-    private int stepCounter = 0;
+    final private StepCounter counter;
+
     @Getter
     private int epochCounter = 0;
 
@@ -39,7 +39,12 @@ public abstract class Learning<O extends Encodable, A, AS extends ActionSpace<A>
     private IHistoryProcessor historyProcessor = null;
 
     public Learning(LConfiguration conf) {
-        random = new Random(conf.getSeed());
+        this(conf, new StepCounter());
+    }
+
+    public Learning(LConfiguration conf, StepCounter counter) {
+        this.random = new Random(conf.getSeed());
+        this.counter = counter;
     }
 
     public static Integer getMaxAction(INDArray vector) {
@@ -117,7 +122,12 @@ public abstract class Learning<O extends Encodable, A, AS extends ActionSpace<A>
     public abstract NN getNeuralNet();
 
     public int incrementStep() {
-        return stepCounter++;
+        return this.counter.increment();
+    }
+
+    @Override
+    public int getStepCounter() {
+        return this.counter.getStepCounter();
     }
 
     public int incrementEpoch() {

--- a/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/StepCounter.java
+++ b/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/StepCounter.java
@@ -1,0 +1,18 @@
+package org.deeplearning4j.rl4j.learning;
+
+import lombok.Getter;
+
+/**
+ * A simple step counter that can be injected into a Learning object. An object that gets injected
+ * into a to be constructed Learning object will not have access to the Learning object as it has not yet been created.
+ * To avoid such cycles we inject all the dependencies into the learning tree itself.
+ */
+public class StepCounter implements StepCountable {
+
+    @Getter
+    private int stepCounter = 0;
+
+    public int increment() {
+        return this.stepCounter++;
+    }
+}

--- a/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/sync/SyncLearning.java
+++ b/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/sync/SyncLearning.java
@@ -2,6 +2,7 @@ package org.deeplearning4j.rl4j.learning.sync;
 
 import lombok.extern.slf4j.Slf4j;
 import org.deeplearning4j.rl4j.learning.Learning;
+import org.deeplearning4j.rl4j.learning.StepCounter;
 import org.deeplearning4j.rl4j.network.NeuralNet;
 import org.deeplearning4j.rl4j.space.ActionSpace;
 import org.deeplearning4j.rl4j.space.Encodable;
@@ -23,6 +24,11 @@ public abstract class SyncLearning<O extends Encodable, A, AS extends ActionSpac
 
     public SyncLearning(LConfiguration conf) {
         super(conf);
+    }
+
+    public SyncLearning(LConfiguration conf,
+                        StepCounter counter) {
+        super(conf, counter);
     }
 
     public void train() {

--- a/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/sync/qlearning/QLearning.java
+++ b/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/sync/qlearning/QLearning.java
@@ -35,7 +35,7 @@ public abstract class QLearning<O extends Encodable, A, AS extends ActionSpace<A
         expReplay = new ExpReplay<>(conf.getExpRepMaxSize(), conf.getBatchSize(), conf.getSeed());
     }
 
-    protected abstract EpsGreedy<O, A, AS> getEgPolicy();
+    protected abstract EpsGreedy<O, A> getEgPolicy();
 
     public abstract MDP<O, A, AS> getMdp();
 

--- a/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/sync/qlearning/discrete/QLearningDiscrete.java
+++ b/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/sync/qlearning/discrete/QLearningDiscrete.java
@@ -1,10 +1,13 @@
 package org.deeplearning4j.rl4j.learning.sync.qlearning.discrete;
 
+import com.kitfox.svg.A;
 import lombok.Getter;
 import lombok.Setter;
 import org.nd4j.linalg.primitives.Pair;
 import org.deeplearning4j.gym.StepReply;
 import org.deeplearning4j.rl4j.learning.Learning;
+import org.deeplearning4j.rl4j.learning.StepCounter;
+import org.deeplearning4j.rl4j.learning.sync.IExpReplay;
 import org.deeplearning4j.rl4j.learning.sync.Transition;
 import org.deeplearning4j.rl4j.learning.sync.qlearning.QLearning;
 import org.deeplearning4j.rl4j.mdp.MDP;
@@ -25,14 +28,12 @@ import java.util.ArrayList;
 
 /**
  * @author rubenfiszel (ruben.fiszel@epfl.ch) 7/18/16.
- *
+ * <p>
  * DQN or Deep Q-Learning in the Discrete domain
- *
+ * <p>
  * http://arxiv.org/abs/1312.5602
- *
  */
 public abstract class QLearningDiscrete<O extends Encodable> extends QLearning<O, Integer, DiscreteSpace> {
-
     @Getter
     final private QLConfiguration configuration;
     @Getter
@@ -54,26 +55,46 @@ public abstract class QLearningDiscrete<O extends Encodable> extends QLearning<O
     private int lastMonitor = -Constants.MONITOR_FREQ;
 
 
-    public QLearningDiscrete(MDP<O, Integer, DiscreteSpace> mdp, IDQN dqn, QLConfiguration conf,
-                    DataManager dataManager, int epsilonNbStep) {
+    public QLearningDiscrete(MDP<O, Integer,
+            DiscreteSpace> mdp,
+                             IDQN dqn,
+                             QLConfiguration conf,
+                             DataManager dataManager,
+                             int epsilonNbStep) {
         super(conf);
         this.configuration = conf;
         this.mdp = mdp;
         this.dataManager = dataManager;
-        currentDQN = dqn;
-        targetDQN = dqn.clone();
-        policy = new DQNPolicy(getCurrentDQN());
-        egPolicy = new EpsGreedy(policy, mdp, conf.getUpdateStart(), epsilonNbStep, getRandom(), conf.getMinEpsilon(),
-                        this);
+        this.currentDQN = dqn;
+        this.targetDQN = dqn.clone();
+        this.policy = new DQNPolicy(getCurrentDQN());
+        this.egPolicy = new EpsGreedy<>(policy, mdp, conf.getUpdateStart(), epsilonNbStep,
+                getRandom(), conf.getMinEpsilon(), this);
         mdp.getActionSpace().setSeed(conf.getSeed());
     }
 
+    public QLearningDiscrete(StepCounter counter,
+                             IExpReplay<Integer> replay,
+                             DQNPolicy<O> policy,
+                             EpsGreedy<O, Integer> egPolicy,
+                             MDP<O, Integer, DiscreteSpace> mdp,
+                             IDQN dqn,
+                             QLConfiguration conf,
+                             DataManager dataManager) {
+        super(conf, counter, replay);
+        this.configuration = conf;
+        this.mdp = mdp;
+        this.dataManager = dataManager;
+        this.currentDQN = dqn;
+        this.targetDQN = dqn.clone();
+        this.policy = policy;
+        this.egPolicy = egPolicy;
+        mdp.getActionSpace().setSeed(conf.getSeed());
+    }
 
     public void postEpoch() {
-
         if (getHistoryProcessor() != null)
             getHistoryProcessor().stopMonitor();
-
     }
 
     public void preEpoch() {
@@ -82,21 +103,21 @@ public abstract class QLearningDiscrete<O extends Encodable> extends QLearning<O
         accuReward = 0;
 
         if (getStepCounter() - lastMonitor >= Constants.MONITOR_FREQ && getHistoryProcessor() != null
-                        && getDataManager().isSaveData()) {
+                && getDataManager().isSaveData()) {
             lastMonitor = getStepCounter();
             int[] shape = getMdp().getObservationSpace().getShape();
             getHistoryProcessor().startMonitor(getDataManager().getVideoDir() + "/video-" + getEpochCounter() + "-"
-                            + getStepCounter() + ".mp4", shape);
+                    + getStepCounter() + ".mp4", shape);
         }
     }
 
     /**
      * Single step of training
+     *
      * @param obs last obs
      * @return relevant info for next step
      */
     protected QLStepReturn<O> trainStep(O obs) {
-
         Integer action;
         INDArray input = getInput(obs);
         boolean isHistoryProcessor = getHistoryProcessor() != null;
@@ -108,7 +129,7 @@ public abstract class QLearningDiscrete<O extends Encodable> extends QLearning<O
         int skipFrame = isHistoryProcessor ? getHistoryProcessor().getConf().getSkipFrame() : 1;
         int historyLength = isHistoryProcessor ? getHistoryProcessor().getConf().getHistoryLength() : 1;
         int updateStart = getConfiguration().getUpdateStart()
-                        + ((getConfiguration().getBatchSize() + historyLength) * skipFrame);
+                + ((getConfiguration().getBatchSize() + historyLength) * skipFrame);
 
         Double maxQ = Double.NaN; //ignore if Nan for stats
 
@@ -121,7 +142,7 @@ public abstract class QLearningDiscrete<O extends Encodable> extends QLearning<O
                     getHistoryProcessor().add(input);
                     history = getHistoryProcessor().getHistory();
                 } else
-                    history = new INDArray[] {input};
+                    history = new INDArray[]{input};
             }
             //concat the history into a single INDArray input
             INDArray hstack = Transition.concat(Transition.dup(history));
@@ -153,7 +174,7 @@ public abstract class QLearningDiscrete<O extends Encodable> extends QLearning<O
             if (isHistoryProcessor)
                 getHistoryProcessor().add(ninput);
 
-            INDArray[] nhistory = isHistoryProcessor ? getHistoryProcessor().getHistory() : new INDArray[] {ninput};
+            INDArray[] nhistory = isHistoryProcessor ? getHistoryProcessor().getHistory() : new INDArray[]{ninput};
 
             Transition<Integer> trans = new Transition(history, action, accuReward, stepReply.isDone(), nhistory[0]);
             getExpReplay().store(trans);
@@ -172,7 +193,6 @@ public abstract class QLearningDiscrete<O extends Encodable> extends QLearning<O
 
     }
 
-
     protected Pair<INDArray, INDArray> setTarget(ArrayList<Transition<Integer>> transitions) {
         if (transitions.size() == 0)
             throw new IllegalArgumentException("too few transitions");
@@ -180,7 +200,7 @@ public abstract class QLearningDiscrete<O extends Encodable> extends QLearning<O
         int size = transitions.size();
 
         int[] shape = getHistoryProcessor() == null ? getMdp().getObservationSpace().getShape()
-                        : getHistoryProcessor().getConf().getShape();
+                : getHistoryProcessor().getConf().getShape();
         int[] nshape = makeShape(size, shape);
         INDArray obs = Nd4j.create(nshape);
         INDArray nextObs = Nd4j.create(nshape);
@@ -197,7 +217,7 @@ public abstract class QLearningDiscrete<O extends Encodable> extends QLearning<O
                 obs.putRow(i, obsArray[0]);
             } else {
                 for (int j = 0; j < obsArray.length; j++) {
-                    obs.put(new INDArrayIndex[] {NDArrayIndex.point(i), NDArrayIndex.point(j)}, obsArray[j]);
+                    obs.put(new INDArrayIndex[]{NDArrayIndex.point(i), NDArrayIndex.point(j)}, obsArray[j]);
                 }
             }
 
@@ -206,7 +226,7 @@ public abstract class QLearningDiscrete<O extends Encodable> extends QLearning<O
                 nextObs.putRow(i, nextObsArray[0]);
             } else {
                 for (int j = 0; j < nextObsArray.length; j++) {
-                    nextObs.put(new INDArrayIndex[] {NDArrayIndex.point(i), NDArrayIndex.point(j)}, nextObsArray[j]);
+                    nextObs.put(new INDArrayIndex[]{NDArrayIndex.point(i), NDArrayIndex.point(j)}, nextObsArray[j]);
                 }
             }
         }
@@ -216,19 +236,18 @@ public abstract class QLearningDiscrete<O extends Encodable> extends QLearning<O
         }
 
         INDArray dqnOutputAr = dqnOutput(obs);
-
         INDArray dqnOutputNext = dqnOutput(nextObs);
-        INDArray targetDqnOutputNext = null;
 
+        INDArray targetDqnOutputNext = null;
         INDArray tempQ = null;
         INDArray getMaxAction = null;
+
         if (getConfiguration().isDoubleDQN()) {
             targetDqnOutputNext = targetDqnOutput(nextObs);
             getMaxAction = Nd4j.argMax(dqnOutputNext, 1);
         } else {
             tempQ = Nd4j.max(dqnOutputNext, 1);
         }
-
 
         for (int i = 0; i < size; i++) {
             double yTar = transitions.get(i).getReward();
@@ -243,8 +262,6 @@ public abstract class QLearningDiscrete<O extends Encodable> extends QLearning<O
 
             }
 
-
-
             double previousV = dqnOutputAr.getDouble(i, actions[i]);
             double lowB = previousV - getConfiguration().getErrorClamp();
             double highB = previousV + getConfiguration().getErrorClamp();
@@ -255,5 +272,5 @@ public abstract class QLearningDiscrete<O extends Encodable> extends QLearning<O
 
         return new Pair(obs, dqnOutputAr);
     }
-
 }
+

--- a/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/sync/qlearning/discrete/QLearningDiscrete.java
+++ b/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/sync/qlearning/discrete/QLearningDiscrete.java
@@ -44,7 +44,7 @@ public abstract class QLearningDiscrete<O extends Encodable> extends QLearning<O
     @Getter
     private DQNPolicy<O> policy;
     @Getter
-    private EpsGreedy<O, Integer, DiscreteSpace> egPolicy;
+    private EpsGreedy<O, Integer> egPolicy;
     @Getter
     @Setter
     private IDQN targetDQN;

--- a/rl4j-core/src/main/java/org/deeplearning4j/rl4j/policy/EpsGreedy.java
+++ b/rl4j-core/src/main/java/org/deeplearning4j/rl4j/policy/EpsGreedy.java
@@ -3,6 +3,7 @@ package org.deeplearning4j.rl4j.policy;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.deeplearning4j.rl4j.learning.StepCountable;
+import org.deeplearning4j.rl4j.mdp.HasActionSpace;
 import org.deeplearning4j.rl4j.mdp.MDP;
 import org.deeplearning4j.rl4j.network.NeuralNet;
 import org.deeplearning4j.rl4j.space.Encodable;

--- a/rl4j-core/src/main/java/org/deeplearning4j/rl4j/policy/EpsGreedy.java
+++ b/rl4j-core/src/main/java/org/deeplearning4j/rl4j/policy/EpsGreedy.java
@@ -5,28 +5,27 @@ import lombok.extern.slf4j.Slf4j;
 import org.deeplearning4j.rl4j.learning.StepCountable;
 import org.deeplearning4j.rl4j.mdp.MDP;
 import org.deeplearning4j.rl4j.network.NeuralNet;
-import org.deeplearning4j.rl4j.space.ActionSpace;
 import org.deeplearning4j.rl4j.space.Encodable;
 import org.nd4j.linalg.api.ndarray.INDArray;
 
 import java.util.Random;
 
 /**
+ * An epsilon greedy policy chooses the next action either randomly or passes
+ * it on to a policy to decide the next action.
+ * <p>
+ * Episilon is annealed to minEpsilon over epsilonNbStep steps, so as time progresses it
+ * is more likely that the policy (neural net) will be used to determine the next action
+ * vs. just randomly picking one.
+ *
  * @author rubenfiszel (ruben.fiszel@epfl.ch) 7/24/16.
- *
- * An epsilon greedy policy choose the next action
- * - randomly with epsilon probability
- * - deleguate it to constructor argument 'policy' with (1-epsilon) probability.
- *
- * epislon is annealed to minEpsilon over epsilonNbStep steps
- *
  */
 @AllArgsConstructor
 @Slf4j
-public class EpsGreedy<O extends Encodable, A, AS extends ActionSpace<A>> extends Policy<O, A> {
+public class EpsGreedy<O extends Encodable, A> extends Policy<O, A> {
 
     final private Policy<O, A> policy;
-    final private MDP<O, A, AS> mdp;
+    final private MDP<?, A, ?> mdp;
     final private int updateStart;
     final private int epsilonNbStep;
     final private Random rd;
@@ -38,16 +37,14 @@ public class EpsGreedy<O extends Encodable, A, AS extends ActionSpace<A>> extend
     }
 
     public A nextAction(INDArray input) {
-
         float ep = getEpsilon();
         if (learning.getStepCounter() % 500 == 1)
             log.info("EP: " + ep + " " + learning.getStepCounter());
+
         if (rd.nextFloat() > ep)
             return policy.nextAction(input);
         else
             return mdp.getActionSpace().randomAction();
-
-
     }
 
     public float getEpsilon() {

--- a/rl4j-core/src/test/java/org/deeplearning4j/rl4j/learning/sync/qlearning/QLConfigurationTest.java
+++ b/rl4j-core/src/test/java/org/deeplearning4j/rl4j/learning/sync/qlearning/QLConfigurationTest.java
@@ -1,0 +1,32 @@
+package org.deeplearning4j.rl4j.learning.sync.qlearning;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class QLConfigurationTest {
+    @Test
+    public void serialize() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        QLearning.QLConfiguration qlConfiguration =
+                new QLearning.QLConfiguration(
+                        123,    //Random seed
+                        200,    //Max step By epoch
+                        8000, //Max step
+                        150000, //Max size of experience replay
+                        32,     //size of batches
+                        500,    //target update (hard)
+                        10,     //num step noop warmup
+                        0.01,   //reward scaling
+                        0.99,   //gamma
+                        1.0,    //td-error clipping
+                        0.1f,   //min epsilon
+                        10000,   //num step for eps greedy anneal
+                        true    //double DQN
+                );
+        String json = mapper.writeValueAsString(qlConfiguration);
+        QLearning.QLConfiguration cnf = mapper.readValue(json, QLearning.QLConfiguration.class);
+    }
+
+}


### PR DESCRIPTION
- Previously this class exposed the generic AS, which is unused and not
  externally visible. We now make this type internal, simplifying the
  code.

- Risk of breaking change is minimal as this is a protected getter.

Test: mvn install succeeds.

## What changes were proposed in this pull request?

The training policy is leaking types.

## How was this patch tested?

mvn install succeeds.