### PR TITLE
Fix serialization of configuration.

### DIFF
--- a/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/sync/qlearning/QLearning.java
+++ b/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/sync/qlearning/QLearning.java
@@ -27,7 +27,7 @@ import java.util.List;
  */
 @Slf4j
 public abstract class QLearning<O extends Encodable, A, AS extends ActionSpace<A>>
-        extends SyncLearning<O, A, AS, IDQN> {
+                extends SyncLearning<O, A, AS, IDQN> {
 
     @Getter
     final private IExpReplay<A> expReplay;
@@ -112,7 +112,7 @@ public abstract class QLearning<O extends Encodable, A, AS extends ActionSpace<A
 
 
         StatEntry statEntry = new QLStatEntry(getStepCounter(), getEpochCounter(), reward, step, scores,
-                getEgPolicy().getEpsilon(), startQ, meanQ);
+                        getEgPolicy().getEpsilon(), startQ, meanQ);
 
         return statEntry;
 

--- a/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/sync/qlearning/QLearning.java
+++ b/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/sync/qlearning/QLearning.java
@@ -1,5 +1,7 @@
 package org.deeplearning4j.rl4j.learning.sync.qlearning;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 import org.deeplearning4j.gym.StepReply;
@@ -19,13 +21,13 @@ import java.util.List;
 
 /**
  * @author rubenfiszel (ruben.fiszel@epfl.ch) 7/19/16.
- *
+ * <p>
  * Mother class for QLearning in the Discrete domain and
  * hopefully one day for the  Continuous domain.
  */
 @Slf4j
 public abstract class QLearning<O extends Encodable, A, AS extends ActionSpace<A>>
-                extends SyncLearning<O, A, AS, IDQN> {
+        extends SyncLearning<O, A, AS, IDQN> {
 
     @Getter
     final private IExpReplay<A> expReplay;
@@ -110,7 +112,7 @@ public abstract class QLearning<O extends Encodable, A, AS extends ActionSpace<A
 
 
         StatEntry statEntry = new QLStatEntry(getStepCounter(), getEpochCounter(), reward, step, scores,
-                        getEgPolicy().getEpsilon(), startQ, meanQ);
+                getEgPolicy().getEpsilon(), startQ, meanQ);
 
         return statEntry;
 
@@ -144,6 +146,7 @@ public abstract class QLearning<O extends Encodable, A, AS extends ActionSpace<A
     @AllArgsConstructor
     @Builder
     @EqualsAndHashCode(callSuper = false)
+    @JsonDeserialize(builder = QLConfiguration.QLConfigurationBuilder.class)
     public static class QLConfiguration implements LConfiguration {
 
         int seed;
@@ -160,6 +163,9 @@ public abstract class QLearning<O extends Encodable, A, AS extends ActionSpace<A
         int epsilonNbStep;
         boolean doubleDQN;
 
+        @JsonPOJOBuilder(withPrefix = "")
+        public static final class QLConfigurationBuilder {
+        }
     }
 
 

--- a/rl4j-core/src/test/java/org/deeplearning4j/rl4j/learning/sync/qlearning/QLConfigurationTest.java
+++ b/rl4j-core/src/test/java/org/deeplearning4j/rl4j/learning/sync/qlearning/QLConfigurationTest.java
@@ -1,0 +1,36 @@
+package org.deeplearning4j.rl4j.learning.sync.qlearning;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class QLConfigurationTest {
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void serialize() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        QLearning.QLConfiguration qlConfiguration =
+                new QLearning.QLConfiguration(
+                        123,    //Random seed
+                        200,    //Max step By epoch
+                        8000, //Max step
+                        150000, //Max size of experience replay
+                        32,     //size of batches
+                        500,    //target update (hard)
+                        10,     //num step noop warmup
+                        0.01,   //reward scaling
+                        0.99,   //gamma
+                        1.0,    //td error clipping
+                        0.1f,   //min epsilon
+                        10000,   //num step for eps greedy anneal
+                        true    //double DQN
+                );
+
+        // Should not throw..
+        String json = mapper.writeValueAsString(qlConfiguration);
+        QLearning.QLConfiguration cnf = mapper.readValue(json, QLearning.QLConfiguration.class);
+    }
+}


### PR DESCRIPTION
It was not possible to deserialize the configuration, breaking loading
of training files from the datamanager.

Test: Unit test validates no thrown exceptions.

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)

Please review
https://github.com/deeplearning4j/deeplearning4j/blob/master/CONTRIBUTING.md before opening a pull request.
