### PR TITLE
Fix malformed xml in lifecycle-mapping of lint-maven plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -267,7 +267,9 @@
                         <groupId>com.lewisd</groupId>
                         <artifactId>lint-maven-plugin</artifactId>
                         <versionRange>[0.0.11,)</versionRange>
-                        <goal>check</goal>
+                        <goals>
+                          <goal>check</goal>
+                        </goals>
                       </pluginExecutionFilter>
                       <action>
                         <ignore/>


### PR DESCRIPTION
See https://github.com/deeplearning4j/nd4j/pull/2233