### PR TITLE
Fixes for updater API change

### DIFF
--- a/rl4j-core/src/main/java/org/deeplearning4j/rl4j/network/ac/ActorCriticCompGraph.java
+++ b/rl4j-core/src/main/java/org/deeplearning4j/rl4j/network/ac/ActorCriticCompGraph.java
@@ -6,6 +6,7 @@ import org.deeplearning4j.nn.conf.ComputationGraphConfiguration;
 import org.deeplearning4j.nn.gradient.Gradient;
 import org.deeplearning4j.nn.graph.ComputationGraph;
 import org.deeplearning4j.nn.layers.recurrent.RnnOutputLayer;
+import org.deeplearning4j.nn.workspace.LayerWorkspaceMgr;
 import org.deeplearning4j.optimize.api.IterationListener;
 import org.deeplearning4j.optimize.api.TrainingListener;
 import org.deeplearning4j.util.ModelSerializer;
@@ -92,7 +93,7 @@ public class ActorCriticCompGraph<NN extends ActorCriticCompGraph> implements IA
         ComputationGraphConfiguration cgConf = cg.getConfiguration();
         int iterationCount = cgConf.getIterationCount();
         int epochCount = cgConf.getEpochCount();
-        cg.getUpdater().update(gradient[0], iterationCount, epochCount, batchSize);
+        cg.getUpdater().update(gradient[0], iterationCount, epochCount, batchSize, LayerWorkspaceMgr.noWorkspaces());
         cg.params().subi(gradient[0].gradient());
         Collection<IterationListener> iterationListeners = cg.getListeners();
         if (iterationListeners != null && iterationListeners.size() > 0) {

--- a/rl4j-core/src/main/java/org/deeplearning4j/rl4j/network/ac/ActorCriticSeparate.java
+++ b/rl4j-core/src/main/java/org/deeplearning4j/rl4j/network/ac/ActorCriticSeparate.java
@@ -6,6 +6,7 @@ import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
 import org.deeplearning4j.nn.gradient.Gradient;
 import org.deeplearning4j.nn.layers.recurrent.RnnOutputLayer;
 import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
+import org.deeplearning4j.nn.workspace.LayerWorkspaceMgr;
 import org.deeplearning4j.optimize.api.IterationListener;
 import org.deeplearning4j.optimize.api.TrainingListener;
 import org.deeplearning4j.util.ModelSerializer;
@@ -107,7 +108,7 @@ public class ActorCriticSeparate<NN extends ActorCriticSeparate> implements IAct
         MultiLayerConfiguration valueConf = valueNet.getLayerWiseConfigurations();
         int valueIterationCount = valueConf.getIterationCount();
         int valueEpochCount = valueConf.getEpochCount();
-        valueNet.getUpdater().update(valueNet, gradient[0], valueIterationCount, valueEpochCount, batchSize);
+        valueNet.getUpdater().update(valueNet, gradient[0], valueIterationCount, valueEpochCount, batchSize, LayerWorkspaceMgr.noWorkspaces());
         valueNet.params().subi(gradient[0].gradient());
         Collection<IterationListener> valueIterationListeners = valueNet.getListeners();
         if (valueIterationListeners != null && valueIterationListeners.size() > 0) {
@@ -120,7 +121,7 @@ public class ActorCriticSeparate<NN extends ActorCriticSeparate> implements IAct
         MultiLayerConfiguration policyConf = policyNet.getLayerWiseConfigurations();
         int policyIterationCount = policyConf.getIterationCount();
         int policyEpochCount = policyConf.getEpochCount();
-        policyNet.getUpdater().update(policyNet, gradient[1], policyIterationCount, policyEpochCount, batchSize);
+        policyNet.getUpdater().update(policyNet, gradient[1], policyIterationCount, policyEpochCount, batchSize, LayerWorkspaceMgr.noWorkspaces());
         policyNet.params().subi(gradient[1].gradient());
         Collection<IterationListener> policyIterationListeners = policyNet.getListeners();
         if (policyIterationListeners != null && policyIterationListeners.size() > 0) {

--- a/rl4j-core/src/main/java/org/deeplearning4j/rl4j/network/dqn/DQN.java
+++ b/rl4j-core/src/main/java/org/deeplearning4j/rl4j/network/dqn/DQN.java
@@ -4,6 +4,7 @@ import org.deeplearning4j.nn.api.NeuralNetwork;
 import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
 import org.deeplearning4j.nn.gradient.Gradient;
 import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
+import org.deeplearning4j.nn.workspace.LayerWorkspaceMgr;
 import org.deeplearning4j.optimize.api.IterationListener;
 import org.deeplearning4j.optimize.api.TrainingListener;
 import org.deeplearning4j.util.ModelSerializer;
@@ -92,7 +93,7 @@ public class DQN<NN extends DQN> implements IDQN<NN> {
         MultiLayerConfiguration mlnConf = mln.getLayerWiseConfigurations();
         int iterationCount = mlnConf.getIterationCount();
         int epochCount = mlnConf.getEpochCount();
-        mln.getUpdater().update(mln, gradient[0], iterationCount, epochCount, batchSize);
+        mln.getUpdater().update(mln, gradient[0], iterationCount, epochCount, batchSize, LayerWorkspaceMgr.noWorkspaces());
         mln.params().subi(gradient[0].gradient());
         Collection<IterationListener> iterationListeners = mln.getListeners();
         if (iterationListeners != null && iterationListeners.size() > 0) {


### PR DESCRIPTION
DL4J updater API changed, and I didn't realize/remember it was used directly.
This fixes the updater call given the API change.
Tests (mvn clean test) pass.